### PR TITLE
Add quantile score

### DIFF
--- a/Competition_Bundle_HEP/ingestion_program/ingestion.py
+++ b/Competition_Bundle_HEP/ingestion_program/ingestion.py
@@ -136,6 +136,9 @@ class Ingestion():
 
         self.mu_hats = predicted_dict["mu_hats"]
         self.delta_mu_hat = predicted_dict["delta_mu_hat"]
+        
+        self.q_1 = predicted_dict["q_1"]
+        self.q_2 = predicted_dict["q_2"]
 
     def save_result(self):
 
@@ -143,10 +146,15 @@ class Ingestion():
 
         result_dict = {
             "delta_mu_hat": self.delta_mu_hat,
-            "mu_hats": self.mu_hats
+            "mu_hats": self.mu_hats,
+            "q_1": self.q_1,
+            "q_2": self.q_2
+        }
         }
         print(f"[*] --- delta_mu_hat: {result_dict['delta_mu_hat']}")
         print(f"[*] --- mu_hats (avg): {np.mean(result_dict['mu_hats'])}")
+        print(f"[*] --- q_1 (avg): {np.mean(result_dict['q_1'])}")
+        print(f"[*] --- q_2 (avg): {np.mean(result_dict['q_2'])}")  
 
         result_file = os.path.join(output_dir, "result.json")
 

--- a/Competition_Bundle_HEP/pages/evaluation.md
+++ b/Competition_Bundle_HEP/pages/evaluation.md
@@ -54,3 +54,23 @@ $\text{Score}\_{MAE} = MAE_{\hat{\mu}} + MAE_{\Delta{\hat{\mu}}} ~~~~~~~~~ (7)$
 <br>
 
 $\text{Score}\_{MSE} = MSE_{\hat{\mu}} + MSE_{\Delta{\hat{\mu}}} ~~~~~~~~~ (8)$
+
+## Score Quantile
+For a given dataset, $\mathbf d$ and unknown parameter $\mu$ we define the $q^\mathrm{th}$ quantile of the posterior distribution $p(\mu | \mathbf d)$ as the value $\mu_q$ such that the probability of $\mu$ being smaller than $\mu_q$ is $q$. The problem posed to participants is to determine the two quantiles $\mu_{25}, \mu_{75}$, i.e. the central region of the parameter space that contains the true value of $\mu$ with a probability of 50%.
+
+We grade participants' algorithms on a test set of $N_\mathrm{test}$ datasets $\mathbf d_i$ where $i = 1~\dots N_\mathrm{test}$ by computing the following metric:
+
+$J_q = \left(\Delta \mu + \epsilon\right) \times f\left(\frac{N_\in}{N_\mathrm{test}} \right), ~~~~~~~~~ (9)$
+
+where:
+
+$N_{\in} = \sum_{i = 1}^{N_\mathrm{ test}} I\left(\mu_{25} \leq \mu \leq \mu_\mathrm{75} \right),~~~~~~~~~ (10)$
+
+and
+
+$\Delta \mu = \frac{1}{N_\mathrm{test}} \sum_{i = 1}^{N_\mathrm{test}}\left(\mu_{75}^i - \mu_{25}^i \right).~~~~~~~~~ (11)$
+
+$\epsilon$ is a small number that regularizes the behavior as $\Delta \mu$ and $N_\in$ as $\Delta \mu$ tends to zero. 
+$f(x)$ is a function that penalizes departure from the target coverage of 50%. The simplest choice for $f(x)$ is the reciprocal of a polynomial $p(x)$ with roots at 0 and 1 and a minimum at 0.5, so we choose $p(x) = x(1 - x)$: 
+
+$f(x) = \frac{p(x=0.5)}{p(x)}.$


### PR DESCRIPTION
Implementation of quantile score. Adds two new quantities to be computed: `q_1` represents the 25th percentile of the distribution $p(\mu | d)$, and `q_2` represents the 75th percentile of that distribution. 

Added these quantities to the ingestion engine and to the scoring script, as well as to the "evaluation" page of the challenge description.