### PR TITLE
Fix 2D generator producing constant signal rate

### DIFF
--- a/Data_Generator/data_generator_physics.py
+++ b/Data_Generator/data_generator_physics.py
@@ -89,8 +89,8 @@ class DataGenerator:
         self.pb = self.settings["p_b"]
         self.ps = round(1 - self.pb, 5)
 
-        self.number_of_signal_events = int(self.total_number_of_events*self.ps)
-        self.number_of_background_events = int(self.total_number_of_events * self.pb)
+        self.number_of_signal_events = np.random.binomial(self.total_number_of_events, p=self.ps, size=None)    
+        self.number_of_background_events = self.total_number_of_events - self.number_of_signal_events
 
         # -----------------------------------------------
         # Load Background distribution


### PR DESCRIPTION
In the past implementation, the ratio between the number of signal and background events was always constant, but in a realistic case, there are random fluctuations that make is so that the ratio varies. This change fixes it by sampling the actual signal and background numbers from a binomial